### PR TITLE
修复npm install失败的问题，为index-list组件添加样式

### DIFF
--- a/docs/index-list.md
+++ b/docs/index-list.md
@@ -6,7 +6,7 @@
 
 | 属性       | 类型            | 默认值 | 必填 | 说明                                  |
 | ---------- | --------------- | ------ | ---- | ------------------------------------- |
-| list       | Array<listItem> | []     | 是   | 列表数据                              |
+| list       | Array\<listItem> | []     | 是   | 列表数据                              |
 | vibrated   | boolean         | true   | 否   | 索引上滑动时是否产生振动，仅 iOS 生效 |
 | bindchoose | eventhandle     |      |   否   | 选择列表项, e.detail={name}           |
 
@@ -15,13 +15,21 @@
 | 属性     | 类型           | 说明         |
 | -------- | -------------- | ------------ |
 | alpha    | string         | 首字母(大写) |
-| subItems | Array<subItem> | 子元素集合   |
+| subItems | Array\<subItem> | 子元素集合   |
 
 ### subItem 属性列表
 
-| 属性 | 类型   | 说明 |
-| ---- | ------ | ---- |
-| name | string | 名称 |
+| 属性 | 类型   | 必填 | 说明 |
+| ---- | ------ | -- | ---- |
+| name | string | 是 | 名称 |
+| style | string | 否 | 样式 |
+
+### style 的合法值
+
+| 属性 | 类型                   |
+| ---- | ---------------------- |
+| selected | 高亮该条目   |
+| disabled | 将该条目置为不可用状态 |       |
 
 ### 注意事项
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
-    "@tencent/tslint-config-wxapp": "0.0.2",
     "autoprefixer": "^6.5.1",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",

--- a/src/index-list/index.less
+++ b/src/index-list/index.less
@@ -39,6 +39,15 @@
 .index-group__item.thin-border-bottom:after{
 	left: 24rpx;
 }
+.selected{
+	color: #1aad19;
+}
+.disabled{
+	color: hsla(0,0%,100%,.2);
+}
+.bg-highlight,.selected{
+	background-color: #f2f2f2;
+}
 
 .anchor-bar__wrp{
 	position: fixed;

--- a/src/index-list/index.wxml
+++ b/src/index-list/index.wxml
@@ -15,7 +15,7 @@
       <view class="index-group__list">
         <block wx:for="{{item.subItems}}" wx:for-item="subItem" wx:key="name">
           <view 
-            class="index-group__item thin-border-bottom" 
+            class="index-group__item thin-border-bottom {{subItem.style}}" 
             hover-class="bg-highlight" 
             data-item="{{subItem}}"
             bindtap="choose">


### PR DESCRIPTION
## npm install
由于包``````已经被移除，[这个issue](#6)中运行```npm install```失败。这个包的内容是配置typescript linter。此次更新移除了对前述非必要的配置包的依赖。

## index-list
有时我们需要对联系人列表进行多选，而前一版本的```index-list```无法改变列表项的样式。此提交中可以通过更改```subItem```的```style```属性来提供“已选择”和“不可用”两种样式。