### PR TITLE
fix: 修复点击首字母大概率出现首字母被定位到目标上一个字母的问题

### DIFF
--- a/src/index-list/index.ts
+++ b/src/index-list/index.ts
@@ -113,7 +113,7 @@ Component({
             const query = this.createSelectorQuery()
             query.selectAll('.index_list_item').boundingClientRect(rects => {
                 const result: any = rects
-                data._tops = result.map(item => item.top)
+                data._tops = result.map(item => Math.floor(item.top))
             }).exec()
             // 计算右侧字母栏小区块的高度等信息
             query.select('.anchor-list').boundingClientRect(rect => {


### PR DESCRIPTION
这是代码片段
[https://developers.weixin.qq.com/s/IvrsUXmV7LlW](url)