### PR TITLE
feat: 监听 offsetTop，支持动态高度

### DIFF
--- a/src/sticky/index.ts
+++ b/src/sticky/index.ts
@@ -35,13 +35,18 @@ Component({
 
   observers: {
     disabled: function(newVal) {
-      if (!this._attached) return
+      if (!this.data._attached) return
       newVal ? this.disconnectObserver() : this.initObserver()
     },
 
     container: function(newVal) {
       if (typeof newVal !== 'function' || !this.data.height) return
       this.observerContainer()
+    },
+
+    offsetTop: function(newVal){
+      if(typeof newVal !== 'number' || !this.data._attached) return
+      this.initObserver()
     }
     
   },


### PR DESCRIPTION
当自定义顶部 bar 时，高度是动态变化的，此时需监听 offsetTop 属性，即支持如下效果：

```html
<mp-sticky offset-top="{{mpNavigationBarHeight}}"  id="mpSticky"></mp-sticky>
```