### PR TITLE
perf: 隐藏2.12.0+版本小程序上tabs底部滚动条

### DIFF
--- a/src/tabs/index.wxml
+++ b/src/tabs/index.wxml
@@ -1,6 +1,6 @@
 <view class="weui-tabs">
   <view class="weui-tabs-bar__wrp">
-    <scroll-view scroll-x scroll-into-view="item_{{currentView}}">
+    <scroll-view enhanced="{{true}}" show-scrollbar="{{false}}" scroll-x scroll-into-view="item_{{currentView}}">
       <view class="weui-tabs-bar__content">
         <block wx:for="{{tabs}}" wx:key="title">
           <view id="item_{{index}}" class="weui-tabs-bar__item" style="background-color: {{tabBackgroundColor}}; color: {{activeTab === index ? tabActiveTextColor : tabInactiveTextColor}};" bindtap="handleTabClick" data-index="{{index}}">


### PR DESCRIPTION
tabs组件超出宽度会出现滚动条体验不够好。小程序2.12.0之后scroll-view支持隐藏滚动条，所以加上相关属性`enhanced`、`show-scrollbar`控制